### PR TITLE
Update .NET replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This `title-converter` tool takes a string and converts it into the [approved fo
 |Original|Replacement|
 |--------|-----------|
 |A#|`asharp`|
+|ASP.NET|`asp-dotnet`|
 |C#|`csharp`|
 |C++|`cpp`|
 |F#|`fsharp`|

--- a/title-converter.py
+++ b/title-converter.py
@@ -22,7 +22,8 @@ def title_converter():
     user_string = re.sub('[a-z]*#', 'csharp', user_string)
 
     # replace .net with dotnet
-    user_string = re.sub('.net', 'dotnet', user_string)
+    # added extra space to account for tech words like "ASP.NET"
+    user_string = re.sub('.net', ' dotnet', user_string)
         
     # replacing and removing special characters
     for char in user_string:


### PR DESCRIPTION
Update the .NET tech word replacement to account for words like `ASP.NET`.