### PR TITLE
Revert Regex for .NET

### DIFF
--- a/title-converter.py
+++ b/title-converter.py
@@ -19,7 +19,7 @@ def title_converter():
     user_string = re.sub('\+\+', 'pp', user_string)
     
     # replace c# with c-sharp (also works with A#, F#, etc.)
-    user_string = re.sub('[a-z]*#', '*sharp', user_string)
+    user_string = re.sub(r'([a-z]*#)', r'\1sharp', user_string)
 
     # replace asp.net with aspnet
     user_string = re.sub('asp\.net', 'aspnet', user_string)


### PR DESCRIPTION
Reverting regex for .NET substitutions. Created bug to address this in the future (#9 )